### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0](https://github.com/RDMA-Rust/rdma-mummy-sys/compare/v0.1.0...v0.2.0) - 2024-09-24
+
+### Added
+
+- *(verbs)* derive Clone, Copy for ibv_wc
+- *(verbs)* add _compat suffix to ibv_query_port
+
+### Other
+
+- *(verbs)* return T* directly in inline function
+
 ## v0.1.0 (2024-09-01)
 
 ### Documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdma-mummy-sys"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Luke Yue <lukedyue@gmail.com>",
     "Pu Wang <nicolas.weeks@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `rdma-mummy-sys`: 0.1.0 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/RDMA-Rust/rdma-mummy-sys/compare/v0.1.0...v0.2.0) - 2024-09-24

### Added

- *(verbs)* derive Clone, Copy for ibv_wc
- *(verbs)* add _compat suffix to ibv_query_port

### Other

- *(verbs)* return T* directly in inline function
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).