### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3](https://github.com/RDMA-Rust/rdma-mummy-sys/compare/v0.2.2...v0.2.3) - 2026-03-01
+
+### Fixed
+
+- use -I instead of -F for clang include path
+
 ## [0.2.2](https://github.com/RDMA-Rust/rdma-mummy-sys/compare/v0.2.1...v0.2.2) - 2025-06-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdma-mummy-sys"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
     "Luke Yue <lukedyue@gmail.com>",
     "Pu Wang <nicolas.weeks@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `rdma-mummy-sys`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/RDMA-Rust/rdma-mummy-sys/compare/v0.2.2...v0.2.3) - 2026-03-01

### Fixed

- use -I instead of -F for clang include path
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).