### PR TITLE
feat: add mlx5dv bindings behind mlx5 feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ memoffset = "0.9"
 paste = "1.0"
 # intrusive-collections = "0.9"
 
+[features]
+mlx5 = []
+
 [build-dependencies]
 cmake = "0.1"
 bindgen = { version = "0.66", features = ["prettyplease"] }

--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,7 @@ fn main() {
 
     let bindings = bindgen::Builder::default()
         .header("src/bindings.h")
-        .clang_arg("-F./rdma-core-mummy/include")
+        .clang_arg("-I./rdma-core-mummy/include")
         .allowlist_function("ibv_.*")
         .allowlist_function("_ibv_.*")
         .allowlist_type("ibv_.*")

--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,10 @@ fn main() {
         .build_target("all")
         .build();
 
-    println!("cargo:rustc-link-search=native={}", dst.join("build").display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("build").display()
+    );
     println!("cargo:rustc-link-lib=static=ibverbs");
     println!("cargo:rustc-link-lib=static=rdmacm");
 
@@ -143,7 +146,9 @@ fn main() {
 
     let dest_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
 
-    bindings.write_to_file(dest_path).expect("Unable to generate bindings");
+    bindings
+        .write_to_file(dest_path)
+        .expect("Unable to generate bindings");
 
     // Generate mlx5dv bindings when the mlx5 feature is enabled.
     // Requires system-installed mlx5 provider (MLNX_OFED or rdma-core with mlx5).

--- a/build.rs
+++ b/build.rs
@@ -22,10 +22,7 @@ fn main() {
         .build_target("all")
         .build();
 
-    println!(
-        "cargo:rustc-link-search=native={}",
-        dst.join("build").display()
-    );
+    println!("cargo:rustc-link-search=native={}", dst.join("build").display());
     println!("cargo:rustc-link-lib=static=ibverbs");
     println!("cargo:rustc-link-lib=static=rdmacm");
 
@@ -146,9 +143,7 @@ fn main() {
 
     let dest_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
 
-    bindings
-        .write_to_file(dest_path)
-        .expect("Unable to generate bindings");
+    bindings.write_to_file(dest_path).expect("Unable to generate bindings");
 
     // Generate mlx5dv bindings when the mlx5 feature is enabled.
     // Requires system-installed mlx5 provider (MLNX_OFED or rdma-core with mlx5).

--- a/build.rs
+++ b/build.rs
@@ -148,5 +148,47 @@ fn main() {
 
     bindings
         .write_to_file(dest_path)
-        .expect("Couldn't write bindings");
+        .expect("Unable to generate bindings");
+
+    // Generate mlx5dv bindings when the mlx5 feature is enabled.
+    // Requires system-installed mlx5 provider (MLNX_OFED or rdma-core with mlx5).
+    #[cfg(feature = "mlx5")]
+    {
+        println!("cargo:rustc-link-lib=mlx5");
+
+        let mlx5_bindings = bindgen::Builder::default()
+            .header("src/mlx5dv_bindings.h")
+            .clang_arg("-I./rdma-core-mummy/include")
+            .allowlist_function("mlx5dv_.*")
+            .allowlist_type("mlx5dv_.*")
+            .allowlist_type("MLX5DV_.*")
+            .allowlist_var("MLX5DV_.*")
+            // Don't blocklist ibv types — mlx5dv references them.
+            // They'll be generated as opaque types in this module.
+            .blocklist_type("in6_addr")
+            .blocklist_type("sockaddr.*")
+            .blocklist_type("timespec")
+            .opaque_type("pthread_.*")
+            .opaque_type("ibv_context")
+            .opaque_type("ibv_pd")
+            .opaque_type("ibv_cq")
+            .opaque_type("ibv_qp")
+            .opaque_type("ibv_srq")
+            .opaque_type("ibv_wq")
+            .opaque_type("ibv_rwq_ind_table")
+            .derive_copy(true)
+            .derive_debug(false)
+            .derive_default(false)
+            .generate_comments(false)
+            .prepend_enum_name(false)
+            .formatter(bindgen::Formatter::Prettyplease)
+            .size_t_is_usize(true)
+            .generate()
+            .expect("Unable to generate mlx5dv bindings");
+
+        let mlx5_dest = PathBuf::from(env::var("OUT_DIR").unwrap()).join("mlx5dv_bindings.rs");
+        mlx5_bindings
+            .write_to_file(mlx5_dest)
+            .expect("Unable to write mlx5dv bindings");
+    }
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -21,7 +21,8 @@ fn run(ip: &CString, port: &CString) -> i32 {
     let mut res: *mut rdma_addrinfo = null_mut();
 
     hints.ai_port_space = rdma_port_space::RDMA_PS_TCP as i32;
-    let mut ret = unsafe { rdma_getaddrinfo(ip.as_ptr().cast(), port.as_ptr().cast(), &hints, &mut res) };
+    let mut ret =
+        unsafe { rdma_getaddrinfo(ip.as_ptr().cast(), port.as_ptr().cast(), &hints, &mut res) };
 
     if ret != 0 {
         println!("rdma_getaddrinfo");
@@ -152,9 +153,15 @@ fn main() {
     let ret = run(ip, port);
 
     if ret != 0 {
-        println!("rdma_client: ret error {:?}", std::io::Error::from_raw_os_error(-ret));
+        println!(
+            "rdma_client: ret error {:?}",
+            std::io::Error::from_raw_os_error(-ret)
+        );
         if ret == -1 {
-            println!("rdma_client: last os error {:?}", std::io::Error::last_os_error());
+            println!(
+                "rdma_client: last os error {:?}",
+                std::io::Error::last_os_error()
+            );
         }
     }
     println!("rdma_client: end");

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -21,8 +21,7 @@ fn run(ip: &CString, port: &CString) -> i32 {
     let mut res: *mut rdma_addrinfo = null_mut();
 
     hints.ai_port_space = rdma_port_space::RDMA_PS_TCP as i32;
-    let mut ret =
-        unsafe { rdma_getaddrinfo(ip.as_ptr().cast(), port.as_ptr().cast(), &hints, &mut res) };
+    let mut ret = unsafe { rdma_getaddrinfo(ip.as_ptr().cast(), port.as_ptr().cast(), &hints, &mut res) };
 
     if ret != 0 {
         println!("rdma_getaddrinfo");
@@ -153,15 +152,9 @@ fn main() {
     let ret = run(ip, port);
 
     if ret != 0 {
-        println!(
-            "rdma_client: ret error {:?}",
-            std::io::Error::from_raw_os_error(-ret)
-        );
+        println!("rdma_client: ret error {:?}", std::io::Error::from_raw_os_error(-ret));
         if ret == -1 {
-            println!(
-                "rdma_client: last os error {:?}",
-                std::io::Error::last_os_error()
-            );
+            println!("rdma_client: last os error {:?}", std::io::Error::last_os_error());
         }
     }
     println!("rdma_client: end");

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -64,7 +64,7 @@ fn run(ip: &CString, port: &CString) -> i32 {
     }
 
     let mut send_mr = null_mut();
-    if (send_flags & ibv_send_flags::IBV_SEND_INLINE.0) as u32 == 0 {
+    if (send_flags & ibv_send_flags::IBV_SEND_INLINE.0) == 0 {
         println!("flags {:?}", send_flags);
         send_mr = unsafe { rdma_reg_msgs(id, send_msg.as_mut_ptr().cast(), 16) };
         if send_mr.is_null() {
@@ -79,7 +79,7 @@ fn run(ip: &CString, port: &CString) -> i32 {
     ret = unsafe { rdma_post_recv(id, null_mut(), recv_msg.as_mut_ptr().cast(), 16, mr) };
     if ret != 0 {
         println!("rdma_post_recv");
-        if (send_flags & ibv_send_flags::IBV_SEND_INLINE.0) as u32 == 0 {
+        if (send_flags & ibv_send_flags::IBV_SEND_INLINE.0) == 0 {
             unsafe { rdma_dereg_mr(send_mr) };
         }
         return ret;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -24,14 +24,7 @@ fn run() -> i32 {
     let mut res: *mut rdma_addrinfo = null_mut();
     hints.ai_flags = RAI_PASSIVE.try_into().unwrap();
     hints.ai_port_space = rdma_port_space::RDMA_PS_TCP.try_into().unwrap();
-    let mut ret = unsafe {
-        rdma_getaddrinfo(
-            SERVER.as_ptr().cast(),
-            PORT.as_ptr().cast(),
-            &hints,
-            &mut res,
-        )
-    };
+    let mut ret = unsafe { rdma_getaddrinfo(SERVER.as_ptr().cast(), PORT.as_ptr().cast(), &hints, &mut res) };
 
     if ret != 0 {
         println!("rdma_getaddrinfo");
@@ -186,15 +179,9 @@ fn main() {
     println!("rdma_server: start");
     let ret = run();
     if ret != 0 {
-        println!(
-            "rdma_server: ret error {:?}",
-            std::io::Error::from_raw_os_error(-ret)
-        );
+        println!("rdma_server: ret error {:?}", std::io::Error::from_raw_os_error(-ret));
         if ret == -1 {
-            println!(
-                "rdma_server: last os error {:?}",
-                std::io::Error::last_os_error()
-            );
+            println!("rdma_server: last os error {:?}", std::io::Error::last_os_error());
         }
     }
     println!("rdma_server: end");

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -24,7 +24,14 @@ fn run() -> i32 {
     let mut res: *mut rdma_addrinfo = null_mut();
     hints.ai_flags = RAI_PASSIVE.try_into().unwrap();
     hints.ai_port_space = rdma_port_space::RDMA_PS_TCP.try_into().unwrap();
-    let mut ret = unsafe { rdma_getaddrinfo(SERVER.as_ptr().cast(), PORT.as_ptr().cast(), &hints, &mut res) };
+    let mut ret = unsafe {
+        rdma_getaddrinfo(
+            SERVER.as_ptr().cast(),
+            PORT.as_ptr().cast(),
+            &hints,
+            &mut res,
+        )
+    };
 
     if ret != 0 {
         println!("rdma_getaddrinfo");
@@ -179,9 +186,15 @@ fn main() {
     println!("rdma_server: start");
     let ret = run();
     if ret != 0 {
-        println!("rdma_server: ret error {:?}", std::io::Error::from_raw_os_error(-ret));
+        println!(
+            "rdma_server: ret error {:?}",
+            std::io::Error::from_raw_os_error(-ret)
+        );
         if ret == -1 {
-            println!("rdma_server: last os error {:?}", std::io::Error::last_os_error());
+            println!(
+                "rdma_server: last os error {:?}",
+                std::io::Error::last_os_error()
+            );
         }
     }
     println!("rdma_server: end");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 #![deny(warnings)]
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#![allow(clippy::missing_safety_doc, clippy::too_many_arguments)]
+#![allow(
+    clippy::missing_safety_doc,
+    clippy::too_many_arguments,
+    clippy::non_canonical_clone_impl
+)]
 
 use libc::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,13 @@ use libc::*;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
+#[cfg(feature = "mlx5")]
+pub mod mlx5dv {
+    #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+    use libc::*;
+    include!(concat!(env!("OUT_DIR"), "/mlx5dv_bindings.rs"));
+}
+
 mod opcode;
 mod types;
 mod verbs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 #[cfg(feature = "mlx5")]
 pub mod mlx5dv {
     #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+    #![allow(unnecessary_transmutes)]
     use libc::*;
     include!(concat!(env!("OUT_DIR"), "/mlx5dv_bindings.rs"));
 }

--- a/src/mlx5dv_bindings.h
+++ b/src/mlx5dv_bindings.h
@@ -1,0 +1,2 @@
+#include <infiniband/verbs.h>
+#include <infiniband/mlx5dv.h>

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,9 @@
 use crate::*;
 
-/// This file defines the types directly or indirectly involving union,
-/// in that BindGen cannot handle union very well, so mannually define them.
+// This file defines the types directly or indirectly involving union,
+// in that BindGen cannot handle union very well, so manually define them.
 
-/// Struct types involve union in <infiniband/verbs.h>
+// Struct types involve union in <infiniband/verbs.h>
 
 // ibv_gid related union and struct types
 #[repr(C)]
@@ -233,7 +233,7 @@ pub struct ibv_flow_spec {
     pub ibv_flow_spec_union: ibv_flow_spec_union_t,
 }
 
-/// Struct types involve union in <rdma/rdma_cma.h>
+// Struct types involve union in <rdma/rdma_cma.h>
 
 // rdma_addr related union and struct types
 #[repr(C)]
@@ -272,8 +272,7 @@ pub struct rdma_addr {
     pub addr: addr_union_t,
 }
 
-/// rdma_cm_event related union and struct types
-
+// rdma_cm_event related union and struct types
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ibv_ah_attr {

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -3,7 +3,7 @@ use crate::*;
 use std::mem;
 use std::ptr;
 
-/// Inline functions from <infiniband/verbs.h>
+// Inline functions from <infiniband/verbs.h>
 
 pub type ibv_advise_mr_advice = ib_uverbs_advise_mr_advice::Type;
 
@@ -136,7 +136,7 @@ pub unsafe fn ibv_wr_abort(qp: *mut ibv_qp_ex) {
 // ibv_cq_ex related inline functions
 #[inline]
 pub unsafe fn ibv_cq_ex_to_cq(cq: *mut ibv_cq_ex) -> *mut ibv_cq {
-    cq as *mut ibv_cq_ex as *mut ibv_cq
+    cq as *mut ibv_cq
 }
 
 #[inline]
@@ -957,7 +957,7 @@ pub unsafe fn ibv_read_counters(
     }
 }
 
-/// Inline functions from <rdma/rdma_cma.h>
+// Inline functions from <rdma/rdma_cma.h>
 
 pub const RDMA_IB_IP_PS_MASK: u64 = 0xFFFFFFFFFFFF0000;
 pub const RDMA_IB_IP_PORT_MASK: u64 = 0x000000000000FFFF;
@@ -982,8 +982,7 @@ pub unsafe fn rdma_get_peer_addr(id: &rdma_cm_id) -> &libc::sockaddr {
     &id.route.addr.dst_addr_union.dst_addr
 }
 
-/// Inline functions from <rdma/rdma_verbs.h>
-
+// Inline functions from <rdma/rdma_verbs.h>
 #[inline]
 pub unsafe fn rdma_seterrno(ret: c_int) -> c_int {
     if ret != 0 {

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -9,13 +9,7 @@ pub type ibv_advise_mr_advice = ib_uverbs_advise_mr_advice::Type;
 
 // ibv_qp_ex related inline functions
 #[inline]
-pub unsafe fn ibv_wr_atomic_cmp_swp(
-    qp: *mut ibv_qp_ex,
-    rkey: u32,
-    remote_addr: u64,
-    compare: u64,
-    swap: u64,
-) {
+pub unsafe fn ibv_wr_atomic_cmp_swp(qp: *mut ibv_qp_ex, rkey: u32, remote_addr: u64, compare: u64, swap: u64) {
     (*qp).wr_atomic_cmp_swp.unwrap_unchecked()(qp, rkey, remote_addr, compare, swap);
 }
 
@@ -25,12 +19,7 @@ pub unsafe fn ibv_wr_atomic_fetch_add(qp: *mut ibv_qp_ex, rkey: u32, remote_addr
 }
 
 #[inline]
-pub unsafe fn ibv_wr_bind_mw(
-    qp: *mut ibv_qp_ex,
-    mw: *mut ibv_mw,
-    rkey: u32,
-    bind_info: *const ibv_mw_bind_info,
-) {
+pub unsafe fn ibv_wr_bind_mw(qp: *mut ibv_qp_ex, mw: *mut ibv_mw, rkey: u32, bind_info: *const ibv_mw_bind_info) {
     (*qp).wr_bind_mw.unwrap_unchecked()(qp, mw, rkey, bind_info);
 }
 
@@ -50,12 +39,7 @@ pub unsafe fn ibv_wr_rdma_write(qp: *mut ibv_qp_ex, rkey: u32, remote_addr: u64)
 }
 
 #[inline]
-pub unsafe fn ibv_wr_rdma_write_imm(
-    qp: *mut ibv_qp_ex,
-    rkey: u32,
-    remote_addr: u64,
-    imm_data: __be32,
-) {
+pub unsafe fn ibv_wr_rdma_write_imm(qp: *mut ibv_qp_ex, rkey: u32, remote_addr: u64, imm_data: __be32) {
     (*qp).wr_rdma_write_imm.unwrap_unchecked()(qp, rkey, remote_addr, imm_data);
 }
 
@@ -80,12 +64,7 @@ pub unsafe fn ibv_wr_send_tso(qp: *mut ibv_qp_ex, hdr: *mut c_void, hdr_sz: u16,
 }
 
 #[inline]
-pub unsafe fn ibv_wr_set_ud_addr(
-    qp: *mut ibv_qp_ex,
-    ah: *mut ibv_ah,
-    remote_qpn: u32,
-    remote_qkey: u32,
-) {
+pub unsafe fn ibv_wr_set_ud_addr(qp: *mut ibv_qp_ex, ah: *mut ibv_ah, remote_qpn: u32, remote_qkey: u32) {
     (*qp).wr_set_ud_addr.unwrap_unchecked()(qp, ah, remote_qpn, remote_qkey);
 }
 
@@ -100,11 +79,7 @@ pub unsafe fn ibv_wr_set_inline_data(qp: *mut ibv_qp_ex, addr: *mut c_void, leng
 }
 
 #[inline]
-pub unsafe fn ibv_wr_set_inline_data_list(
-    qp: *mut ibv_qp_ex,
-    num_buf: usize,
-    buf_list: *const ibv_data_buf,
-) {
+pub unsafe fn ibv_wr_set_inline_data_list(qp: *mut ibv_qp_ex, num_buf: usize, buf_list: *const ibv_data_buf) {
     (*qp).wr_set_inline_data_list.unwrap_unchecked()(qp, num_buf, buf_list);
 }
 
@@ -252,8 +227,7 @@ pub unsafe fn ibv_post_wq_recv(
 // Use intrusive_collections::container_of! instread, once it's stable not nightly
 macro_rules! container_of {
     ($ptr:expr, $container:path, $field:ident) => {{
-        ($ptr as *const _ as *const u8).sub(memoffset::offset_of!($container, $field))
-            as *const $container
+        ($ptr as *const _ as *const u8).sub(memoffset::offset_of!($container, $field)) as *const $container
     }};
 }
 
@@ -293,11 +267,7 @@ macro_rules! verbs_get_ctx_op {
 
 // ibv_context related inline function
 #[inline]
-pub unsafe fn ibv_query_port(
-    context: *mut ibv_context,
-    port_num: u8,
-    port_attr: *mut ibv_port_attr,
-) -> c_int {
+pub unsafe fn ibv_query_port(context: *mut ibv_context, port_num: u8, port_attr: *mut ibv_port_attr) -> c_int {
     let vcr = verbs_get_ctx_op!(context, query_port);
 
     if let Some(vctx) = vcr {
@@ -317,14 +287,7 @@ pub unsafe fn ibv_query_gid_ex(
     entry: *mut ibv_gid_entry,
     flags: u32,
 ) -> i32 {
-    _ibv_query_gid_ex(
-        context,
-        port_num,
-        gid_index,
-        entry,
-        flags,
-        mem::size_of_val(&*entry),
-    )
+    _ibv_query_gid_ex(context, port_num, gid_index, entry, flags, mem::size_of_val(&*entry))
 }
 
 #[inline]
@@ -334,13 +297,7 @@ pub unsafe fn ibv_query_gid_table(
     max_entries: usize,
     flags: u32,
 ) -> isize {
-    _ibv_query_gid_table(
-        context,
-        entries,
-        max_entries,
-        flags,
-        mem::size_of_val(&*entries),
-    )
+    _ibv_query_gid_table(context, entries, max_entries, flags, mem::size_of_val(&*entries))
 }
 
 // ibv_flow related inline functions
@@ -383,10 +340,7 @@ pub unsafe fn ibv_create_flow_action_esp(
 }
 
 #[inline]
-pub unsafe fn ibv_modify_flow_action_esp(
-    action: *mut ibv_flow_action,
-    esp: *mut ibv_flow_action_esp_attr,
-) -> c_int {
+pub unsafe fn ibv_modify_flow_action_esp(action: *mut ibv_flow_action, esp: *mut ibv_flow_action_esp_attr) -> c_int {
     let vcr = verbs_get_ctx_op!((*action).context, modify_flow_action_esp);
 
     if let Some(vctx) = vcr {
@@ -409,10 +363,7 @@ pub unsafe fn ibv_destroy_flow_action(action: *mut ibv_flow_action) -> c_int {
 
 // ibv_xrcd related inline functions
 #[inline]
-pub unsafe fn ibv_open_xrcd(
-    context: *mut ibv_context,
-    xrcd_init_attr: *mut ibv_xrcd_init_attr,
-) -> *mut ibv_xrcd {
+pub unsafe fn ibv_open_xrcd(context: *mut ibv_context, xrcd_init_attr: *mut ibv_xrcd_init_attr) -> *mut ibv_xrcd {
     let vcr = verbs_get_ctx_op!(context, open_xrcd);
 
     if let Some(vctx) = vcr {
@@ -509,22 +460,12 @@ pub unsafe fn ibv_free_dm(dm: *mut ibv_dm) -> c_int {
 }
 
 #[inline]
-pub unsafe fn ibv_memcpy_to_dm(
-    dm: *mut ibv_dm,
-    dm_offset: u64,
-    host_addr: *const c_void,
-    length: usize,
-) -> c_int {
+pub unsafe fn ibv_memcpy_to_dm(dm: *mut ibv_dm, dm_offset: u64, host_addr: *const c_void, length: usize) -> c_int {
     (*dm).memcpy_to_dm.unwrap()(dm, dm_offset, host_addr, length)
 }
 
 #[inline]
-pub unsafe fn ibv_memcpy_from_dm(
-    host_addr: *mut c_void,
-    dm: *mut ibv_dm,
-    dm_offset: u64,
-    length: usize,
-) -> c_int {
+pub unsafe fn ibv_memcpy_from_dm(host_addr: *mut c_void, dm: *mut ibv_dm, dm_offset: u64, length: usize) -> c_int {
     (*dm).memcpy_from_dm.unwrap()(host_addr, dm, dm_offset, length)
 }
 
@@ -560,10 +501,7 @@ pub unsafe fn ibv_reg_dm_mr(
 
 // ibv_cq_ex related inline function
 #[inline]
-pub unsafe fn ibv_create_cq_ex(
-    context: *mut ibv_context,
-    cq_attr: *mut ibv_cq_init_attr_ex,
-) -> *mut ibv_cq_ex {
+pub unsafe fn ibv_create_cq_ex(context: *mut ibv_context, cq_attr: *mut ibv_cq_init_attr_ex) -> *mut ibv_cq_ex {
     let vcr = verbs_get_ctx_op!(context, create_cq_ex);
 
     if let Some(vctx) = vcr {
@@ -608,17 +546,13 @@ pub unsafe fn ibv_create_srq_ex(
 
     // TODO: verify the condition
     let cond = (mask_inv
-        | (ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_PD
-            & ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_TYPE))
+        | (ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_PD & ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_TYPE))
         != zero
         && (mask & ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_PD) != zero
         && ((mask & ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_TYPE) != zero
             || ((*srq_init_attr_ex).srq_type == ibv_srq_type::IBV_SRQT_BASIC));
     if cond {
-        ibv_create_srq(
-            (*srq_init_attr_ex).pd,
-            srq_init_attr_ex as *mut ibv_srq_init_attr,
-        )
+        ibv_create_srq((*srq_init_attr_ex).pd, srq_init_attr_ex as *mut ibv_srq_init_attr)
     } else {
         let vcr = verbs_get_ctx_op!(context, create_srq_ex);
 
@@ -652,11 +586,7 @@ pub unsafe fn ibv_post_srq_recv(
 }
 
 #[inline]
-pub unsafe fn ibv_post_srq_ops(
-    srq: *mut ibv_srq,
-    op: *mut ibv_ops_wr,
-    bad_op: *mut *mut ibv_ops_wr,
-) -> c_int {
+pub unsafe fn ibv_post_srq_ops(srq: *mut ibv_srq, op: *mut ibv_ops_wr, bad_op: *mut *mut ibv_ops_wr) -> c_int {
     let vcr = verbs_get_ctx_op!((*srq).context, post_srq_ops);
 
     if let Some(vctx) = vcr {
@@ -669,17 +599,11 @@ pub unsafe fn ibv_post_srq_ops(
 
 // ibv_qp related inline functions
 #[inline]
-pub unsafe fn ibv_create_qp_ex(
-    context: *mut ibv_context,
-    qp_init_attr_ex: *mut ibv_qp_init_attr_ex,
-) -> *mut ibv_qp {
+pub unsafe fn ibv_create_qp_ex(context: *mut ibv_context, qp_init_attr_ex: *mut ibv_qp_init_attr_ex) -> *mut ibv_qp {
     let mask = ibv_qp_init_attr_mask((*qp_init_attr_ex).comp_mask);
 
     if mask == ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_PD {
-        ibv_create_qp(
-            (*qp_init_attr_ex).pd,
-            qp_init_attr_ex as *mut ibv_qp_init_attr,
-        )
+        ibv_create_qp((*qp_init_attr_ex).pd, qp_init_attr_ex as *mut ibv_qp_init_attr)
     } else {
         let vcr = verbs_get_ctx_op!(context, create_qp_ex);
 
@@ -694,10 +618,7 @@ pub unsafe fn ibv_create_qp_ex(
 
 // ibv_td related inline functions
 #[inline]
-pub unsafe fn ibv_alloc_td(
-    context: *mut ibv_context,
-    init_attr: *mut ibv_td_init_attr,
-) -> *mut ibv_td {
+pub unsafe fn ibv_alloc_td(context: *mut ibv_context, init_attr: *mut ibv_td_init_attr) -> *mut ibv_td {
     let vcr = verbs_get_ctx_op!(context, alloc_td);
 
     if let Some(vctx) = vcr {
@@ -737,10 +658,7 @@ pub unsafe fn ibv_alloc_parent_domain(
 
 // device related inline functions
 #[inline]
-pub unsafe fn ibv_query_rt_values_ex(
-    context: *mut ibv_context,
-    values: *mut ibv_values_ex,
-) -> c_int {
+pub unsafe fn ibv_query_rt_values_ex(context: *mut ibv_context, values: *mut ibv_values_ex) -> c_int {
     let vcr = verbs_get_ctx_op!(context, query_rt_values);
 
     if let Some(vctx) = vcr {
@@ -771,10 +689,7 @@ pub unsafe fn ibv_query_device_ex(
 
 // ibv_qp related inline functions
 #[inline]
-pub unsafe fn ibv_open_qp(
-    context: *mut ibv_context,
-    qp_open_attr: *mut ibv_qp_open_attr,
-) -> *mut ibv_qp {
+pub unsafe fn ibv_open_qp(context: *mut ibv_context, qp_open_attr: *mut ibv_qp_open_attr) -> *mut ibv_qp {
     let vcr = verbs_get_ctx_op!(context, open_qp);
 
     if let Some(vctx) = vcr {
@@ -786,10 +701,7 @@ pub unsafe fn ibv_open_qp(
 }
 
 #[inline]
-pub unsafe fn ibv_modify_qp_rate_limit(
-    qp: *mut ibv_qp,
-    attr: *mut ibv_qp_rate_limit_attr,
-) -> c_int {
+pub unsafe fn ibv_modify_qp_rate_limit(qp: *mut ibv_qp, attr: *mut ibv_qp_rate_limit_attr) -> c_int {
     let vcr = verbs_get_ctx_op!((*qp).context, modify_qp_rate_limit);
 
     if let Some(vctx) = vcr {
@@ -801,10 +713,7 @@ pub unsafe fn ibv_modify_qp_rate_limit(
 
 // ibv_wq related inline functions
 #[inline]
-pub unsafe fn ibv_create_wq(
-    context: *mut ibv_context,
-    wq_init_attr: *mut ibv_wq_init_attr,
-) -> *mut ibv_wq {
+pub unsafe fn ibv_create_wq(context: *mut ibv_context, wq_init_attr: *mut ibv_wq_init_attr) -> *mut ibv_wq {
     let vcr = verbs_get_ctx_op!(context, create_wq);
 
     if let Some(vctx) = vcr {
@@ -812,10 +721,7 @@ pub unsafe fn ibv_create_wq(
         if !wq.is_null() {
             (*wq).wq_context = (*wq_init_attr).wq_context;
             (*wq).events_completed = 0;
-            libc::pthread_mutex_init(
-                &mut (*wq).mutex,
-                ptr::null_mut::<libc::pthread_mutexattr_t>(),
-            );
+            libc::pthread_mutex_init(&mut (*wq).mutex, ptr::null_mut::<libc::pthread_mutexattr_t>());
             libc::pthread_cond_init(&mut (*wq).cond, ptr::null_mut::<libc::pthread_condattr_t>());
         }
         wq
@@ -877,20 +783,12 @@ pub unsafe fn ibv_destroy_rwq_ind_table(rwq_ind_table: *mut ibv_rwq_ind_table) -
 // If IBV_SEND_INLINE flag is set, the data buffers can be reused
 // immediately after the call returns.
 #[inline]
-pub unsafe fn ibv_post_send(
-    qp: *mut ibv_qp,
-    wr: *mut ibv_send_wr,
-    bad_wr: *mut *mut ibv_send_wr,
-) -> c_int {
+pub unsafe fn ibv_post_send(qp: *mut ibv_qp, wr: *mut ibv_send_wr, bad_wr: *mut *mut ibv_send_wr) -> c_int {
     (*(*qp).context).ops.post_send.unwrap_unchecked()(qp, wr, bad_wr)
 }
 
 #[inline]
-pub unsafe fn ibv_post_recv(
-    qp: *mut ibv_qp,
-    wr: *mut ibv_recv_wr,
-    bad_wr: *mut *mut ibv_recv_wr,
-) -> c_int {
+pub unsafe fn ibv_post_recv(qp: *mut ibv_qp, wr: *mut ibv_recv_wr, bad_wr: *mut *mut ibv_recv_wr) -> c_int {
     (*(*qp).context).ops.post_recv.unwrap_unchecked()(qp, wr, bad_wr)
 }
 
@@ -1009,8 +907,7 @@ pub unsafe fn rdma_reg_read(id: *mut rdma_cm_id, addr: *mut c_void, length: usiz
         (*id).pd,
         addr,
         length,
-        (ibv_access_flags::IBV_ACCESS_LOCAL_WRITE | ibv_access_flags::IBV_ACCESS_REMOTE_READ).0
-            as c_int,
+        (ibv_access_flags::IBV_ACCESS_LOCAL_WRITE | ibv_access_flags::IBV_ACCESS_REMOTE_READ).0 as c_int,
     )
 }
 
@@ -1020,8 +917,7 @@ pub unsafe fn rdma_reg_write(id: *mut rdma_cm_id, addr: *mut c_void, length: usi
         (*id).pd,
         addr,
         length,
-        (ibv_access_flags::IBV_ACCESS_LOCAL_WRITE | ibv_access_flags::IBV_ACCESS_REMOTE_WRITE).0
-            as c_int,
+        (ibv_access_flags::IBV_ACCESS_LOCAL_WRITE | ibv_access_flags::IBV_ACCESS_REMOTE_WRITE).0 as c_int,
     )
 }
 
@@ -1031,12 +927,7 @@ pub unsafe fn rdma_dereg_mr(mr: *mut ibv_mr) -> c_int {
 }
 
 #[inline]
-pub unsafe fn rdma_post_recvv(
-    id: *mut rdma_cm_id,
-    context: *mut c_void,
-    sgl: *mut ibv_sge,
-    nsge: c_int,
-) -> c_int {
+pub unsafe fn rdma_post_recvv(id: *mut rdma_cm_id, context: *mut c_void, sgl: *mut ibv_sge, nsge: c_int) -> c_int {
     let mut wr = ibv_recv_wr {
         wr_id: context as u64,
         next: ptr::null::<ibv_recv_wr>() as *mut _,

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -9,7 +9,13 @@ pub type ibv_advise_mr_advice = ib_uverbs_advise_mr_advice::Type;
 
 // ibv_qp_ex related inline functions
 #[inline]
-pub unsafe fn ibv_wr_atomic_cmp_swp(qp: *mut ibv_qp_ex, rkey: u32, remote_addr: u64, compare: u64, swap: u64) {
+pub unsafe fn ibv_wr_atomic_cmp_swp(
+    qp: *mut ibv_qp_ex,
+    rkey: u32,
+    remote_addr: u64,
+    compare: u64,
+    swap: u64,
+) {
     (*qp).wr_atomic_cmp_swp.unwrap_unchecked()(qp, rkey, remote_addr, compare, swap);
 }
 
@@ -19,7 +25,12 @@ pub unsafe fn ibv_wr_atomic_fetch_add(qp: *mut ibv_qp_ex, rkey: u32, remote_addr
 }
 
 #[inline]
-pub unsafe fn ibv_wr_bind_mw(qp: *mut ibv_qp_ex, mw: *mut ibv_mw, rkey: u32, bind_info: *const ibv_mw_bind_info) {
+pub unsafe fn ibv_wr_bind_mw(
+    qp: *mut ibv_qp_ex,
+    mw: *mut ibv_mw,
+    rkey: u32,
+    bind_info: *const ibv_mw_bind_info,
+) {
     (*qp).wr_bind_mw.unwrap_unchecked()(qp, mw, rkey, bind_info);
 }
 
@@ -39,7 +50,12 @@ pub unsafe fn ibv_wr_rdma_write(qp: *mut ibv_qp_ex, rkey: u32, remote_addr: u64)
 }
 
 #[inline]
-pub unsafe fn ibv_wr_rdma_write_imm(qp: *mut ibv_qp_ex, rkey: u32, remote_addr: u64, imm_data: __be32) {
+pub unsafe fn ibv_wr_rdma_write_imm(
+    qp: *mut ibv_qp_ex,
+    rkey: u32,
+    remote_addr: u64,
+    imm_data: __be32,
+) {
     (*qp).wr_rdma_write_imm.unwrap_unchecked()(qp, rkey, remote_addr, imm_data);
 }
 
@@ -64,7 +80,12 @@ pub unsafe fn ibv_wr_send_tso(qp: *mut ibv_qp_ex, hdr: *mut c_void, hdr_sz: u16,
 }
 
 #[inline]
-pub unsafe fn ibv_wr_set_ud_addr(qp: *mut ibv_qp_ex, ah: *mut ibv_ah, remote_qpn: u32, remote_qkey: u32) {
+pub unsafe fn ibv_wr_set_ud_addr(
+    qp: *mut ibv_qp_ex,
+    ah: *mut ibv_ah,
+    remote_qpn: u32,
+    remote_qkey: u32,
+) {
     (*qp).wr_set_ud_addr.unwrap_unchecked()(qp, ah, remote_qpn, remote_qkey);
 }
 
@@ -79,7 +100,11 @@ pub unsafe fn ibv_wr_set_inline_data(qp: *mut ibv_qp_ex, addr: *mut c_void, leng
 }
 
 #[inline]
-pub unsafe fn ibv_wr_set_inline_data_list(qp: *mut ibv_qp_ex, num_buf: usize, buf_list: *const ibv_data_buf) {
+pub unsafe fn ibv_wr_set_inline_data_list(
+    qp: *mut ibv_qp_ex,
+    num_buf: usize,
+    buf_list: *const ibv_data_buf,
+) {
     (*qp).wr_set_inline_data_list.unwrap_unchecked()(qp, num_buf, buf_list);
 }
 
@@ -227,7 +252,8 @@ pub unsafe fn ibv_post_wq_recv(
 // Use intrusive_collections::container_of! instread, once it's stable not nightly
 macro_rules! container_of {
     ($ptr:expr, $container:path, $field:ident) => {{
-        ($ptr as *const _ as *const u8).sub(memoffset::offset_of!($container, $field)) as *const $container
+        ($ptr as *const _ as *const u8).sub(memoffset::offset_of!($container, $field))
+            as *const $container
     }};
 }
 
@@ -267,7 +293,11 @@ macro_rules! verbs_get_ctx_op {
 
 // ibv_context related inline function
 #[inline]
-pub unsafe fn ibv_query_port(context: *mut ibv_context, port_num: u8, port_attr: *mut ibv_port_attr) -> c_int {
+pub unsafe fn ibv_query_port(
+    context: *mut ibv_context,
+    port_num: u8,
+    port_attr: *mut ibv_port_attr,
+) -> c_int {
     let vcr = verbs_get_ctx_op!(context, query_port);
 
     if let Some(vctx) = vcr {
@@ -287,7 +317,14 @@ pub unsafe fn ibv_query_gid_ex(
     entry: *mut ibv_gid_entry,
     flags: u32,
 ) -> i32 {
-    _ibv_query_gid_ex(context, port_num, gid_index, entry, flags, mem::size_of_val(&*entry))
+    _ibv_query_gid_ex(
+        context,
+        port_num,
+        gid_index,
+        entry,
+        flags,
+        mem::size_of_val(&*entry),
+    )
 }
 
 #[inline]
@@ -297,7 +334,13 @@ pub unsafe fn ibv_query_gid_table(
     max_entries: usize,
     flags: u32,
 ) -> isize {
-    _ibv_query_gid_table(context, entries, max_entries, flags, mem::size_of_val(&*entries))
+    _ibv_query_gid_table(
+        context,
+        entries,
+        max_entries,
+        flags,
+        mem::size_of_val(&*entries),
+    )
 }
 
 // ibv_flow related inline functions
@@ -340,7 +383,10 @@ pub unsafe fn ibv_create_flow_action_esp(
 }
 
 #[inline]
-pub unsafe fn ibv_modify_flow_action_esp(action: *mut ibv_flow_action, esp: *mut ibv_flow_action_esp_attr) -> c_int {
+pub unsafe fn ibv_modify_flow_action_esp(
+    action: *mut ibv_flow_action,
+    esp: *mut ibv_flow_action_esp_attr,
+) -> c_int {
     let vcr = verbs_get_ctx_op!((*action).context, modify_flow_action_esp);
 
     if let Some(vctx) = vcr {
@@ -363,7 +409,10 @@ pub unsafe fn ibv_destroy_flow_action(action: *mut ibv_flow_action) -> c_int {
 
 // ibv_xrcd related inline functions
 #[inline]
-pub unsafe fn ibv_open_xrcd(context: *mut ibv_context, xrcd_init_attr: *mut ibv_xrcd_init_attr) -> *mut ibv_xrcd {
+pub unsafe fn ibv_open_xrcd(
+    context: *mut ibv_context,
+    xrcd_init_attr: *mut ibv_xrcd_init_attr,
+) -> *mut ibv_xrcd {
     let vcr = verbs_get_ctx_op!(context, open_xrcd);
 
     if let Some(vctx) = vcr {
@@ -460,12 +509,22 @@ pub unsafe fn ibv_free_dm(dm: *mut ibv_dm) -> c_int {
 }
 
 #[inline]
-pub unsafe fn ibv_memcpy_to_dm(dm: *mut ibv_dm, dm_offset: u64, host_addr: *const c_void, length: usize) -> c_int {
+pub unsafe fn ibv_memcpy_to_dm(
+    dm: *mut ibv_dm,
+    dm_offset: u64,
+    host_addr: *const c_void,
+    length: usize,
+) -> c_int {
     (*dm).memcpy_to_dm.unwrap()(dm, dm_offset, host_addr, length)
 }
 
 #[inline]
-pub unsafe fn ibv_memcpy_from_dm(host_addr: *mut c_void, dm: *mut ibv_dm, dm_offset: u64, length: usize) -> c_int {
+pub unsafe fn ibv_memcpy_from_dm(
+    host_addr: *mut c_void,
+    dm: *mut ibv_dm,
+    dm_offset: u64,
+    length: usize,
+) -> c_int {
     (*dm).memcpy_from_dm.unwrap()(host_addr, dm, dm_offset, length)
 }
 
@@ -501,7 +560,10 @@ pub unsafe fn ibv_reg_dm_mr(
 
 // ibv_cq_ex related inline function
 #[inline]
-pub unsafe fn ibv_create_cq_ex(context: *mut ibv_context, cq_attr: *mut ibv_cq_init_attr_ex) -> *mut ibv_cq_ex {
+pub unsafe fn ibv_create_cq_ex(
+    context: *mut ibv_context,
+    cq_attr: *mut ibv_cq_init_attr_ex,
+) -> *mut ibv_cq_ex {
     let vcr = verbs_get_ctx_op!(context, create_cq_ex);
 
     if let Some(vctx) = vcr {
@@ -546,13 +608,17 @@ pub unsafe fn ibv_create_srq_ex(
 
     // TODO: verify the condition
     let cond = (mask_inv
-        | (ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_PD & ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_TYPE))
+        | (ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_PD
+            & ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_TYPE))
         != zero
         && (mask & ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_PD) != zero
         && ((mask & ibv_srq_init_attr_mask::IBV_SRQ_INIT_ATTR_TYPE) != zero
             || ((*srq_init_attr_ex).srq_type == ibv_srq_type::IBV_SRQT_BASIC));
     if cond {
-        ibv_create_srq((*srq_init_attr_ex).pd, srq_init_attr_ex as *mut ibv_srq_init_attr)
+        ibv_create_srq(
+            (*srq_init_attr_ex).pd,
+            srq_init_attr_ex as *mut ibv_srq_init_attr,
+        )
     } else {
         let vcr = verbs_get_ctx_op!(context, create_srq_ex);
 
@@ -586,7 +652,11 @@ pub unsafe fn ibv_post_srq_recv(
 }
 
 #[inline]
-pub unsafe fn ibv_post_srq_ops(srq: *mut ibv_srq, op: *mut ibv_ops_wr, bad_op: *mut *mut ibv_ops_wr) -> c_int {
+pub unsafe fn ibv_post_srq_ops(
+    srq: *mut ibv_srq,
+    op: *mut ibv_ops_wr,
+    bad_op: *mut *mut ibv_ops_wr,
+) -> c_int {
     let vcr = verbs_get_ctx_op!((*srq).context, post_srq_ops);
 
     if let Some(vctx) = vcr {
@@ -599,11 +669,17 @@ pub unsafe fn ibv_post_srq_ops(srq: *mut ibv_srq, op: *mut ibv_ops_wr, bad_op: *
 
 // ibv_qp related inline functions
 #[inline]
-pub unsafe fn ibv_create_qp_ex(context: *mut ibv_context, qp_init_attr_ex: *mut ibv_qp_init_attr_ex) -> *mut ibv_qp {
+pub unsafe fn ibv_create_qp_ex(
+    context: *mut ibv_context,
+    qp_init_attr_ex: *mut ibv_qp_init_attr_ex,
+) -> *mut ibv_qp {
     let mask = ibv_qp_init_attr_mask((*qp_init_attr_ex).comp_mask);
 
     if mask == ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_PD {
-        ibv_create_qp((*qp_init_attr_ex).pd, qp_init_attr_ex as *mut ibv_qp_init_attr)
+        ibv_create_qp(
+            (*qp_init_attr_ex).pd,
+            qp_init_attr_ex as *mut ibv_qp_init_attr,
+        )
     } else {
         let vcr = verbs_get_ctx_op!(context, create_qp_ex);
 
@@ -618,7 +694,10 @@ pub unsafe fn ibv_create_qp_ex(context: *mut ibv_context, qp_init_attr_ex: *mut 
 
 // ibv_td related inline functions
 #[inline]
-pub unsafe fn ibv_alloc_td(context: *mut ibv_context, init_attr: *mut ibv_td_init_attr) -> *mut ibv_td {
+pub unsafe fn ibv_alloc_td(
+    context: *mut ibv_context,
+    init_attr: *mut ibv_td_init_attr,
+) -> *mut ibv_td {
     let vcr = verbs_get_ctx_op!(context, alloc_td);
 
     if let Some(vctx) = vcr {
@@ -658,7 +737,10 @@ pub unsafe fn ibv_alloc_parent_domain(
 
 // device related inline functions
 #[inline]
-pub unsafe fn ibv_query_rt_values_ex(context: *mut ibv_context, values: *mut ibv_values_ex) -> c_int {
+pub unsafe fn ibv_query_rt_values_ex(
+    context: *mut ibv_context,
+    values: *mut ibv_values_ex,
+) -> c_int {
     let vcr = verbs_get_ctx_op!(context, query_rt_values);
 
     if let Some(vctx) = vcr {
@@ -689,7 +771,10 @@ pub unsafe fn ibv_query_device_ex(
 
 // ibv_qp related inline functions
 #[inline]
-pub unsafe fn ibv_open_qp(context: *mut ibv_context, qp_open_attr: *mut ibv_qp_open_attr) -> *mut ibv_qp {
+pub unsafe fn ibv_open_qp(
+    context: *mut ibv_context,
+    qp_open_attr: *mut ibv_qp_open_attr,
+) -> *mut ibv_qp {
     let vcr = verbs_get_ctx_op!(context, open_qp);
 
     if let Some(vctx) = vcr {
@@ -701,7 +786,10 @@ pub unsafe fn ibv_open_qp(context: *mut ibv_context, qp_open_attr: *mut ibv_qp_o
 }
 
 #[inline]
-pub unsafe fn ibv_modify_qp_rate_limit(qp: *mut ibv_qp, attr: *mut ibv_qp_rate_limit_attr) -> c_int {
+pub unsafe fn ibv_modify_qp_rate_limit(
+    qp: *mut ibv_qp,
+    attr: *mut ibv_qp_rate_limit_attr,
+) -> c_int {
     let vcr = verbs_get_ctx_op!((*qp).context, modify_qp_rate_limit);
 
     if let Some(vctx) = vcr {
@@ -713,7 +801,10 @@ pub unsafe fn ibv_modify_qp_rate_limit(qp: *mut ibv_qp, attr: *mut ibv_qp_rate_l
 
 // ibv_wq related inline functions
 #[inline]
-pub unsafe fn ibv_create_wq(context: *mut ibv_context, wq_init_attr: *mut ibv_wq_init_attr) -> *mut ibv_wq {
+pub unsafe fn ibv_create_wq(
+    context: *mut ibv_context,
+    wq_init_attr: *mut ibv_wq_init_attr,
+) -> *mut ibv_wq {
     let vcr = verbs_get_ctx_op!(context, create_wq);
 
     if let Some(vctx) = vcr {
@@ -721,7 +812,10 @@ pub unsafe fn ibv_create_wq(context: *mut ibv_context, wq_init_attr: *mut ibv_wq
         if !wq.is_null() {
             (*wq).wq_context = (*wq_init_attr).wq_context;
             (*wq).events_completed = 0;
-            libc::pthread_mutex_init(&mut (*wq).mutex, ptr::null_mut::<libc::pthread_mutexattr_t>());
+            libc::pthread_mutex_init(
+                &mut (*wq).mutex,
+                ptr::null_mut::<libc::pthread_mutexattr_t>(),
+            );
             libc::pthread_cond_init(&mut (*wq).cond, ptr::null_mut::<libc::pthread_condattr_t>());
         }
         wq
@@ -783,12 +877,20 @@ pub unsafe fn ibv_destroy_rwq_ind_table(rwq_ind_table: *mut ibv_rwq_ind_table) -
 // If IBV_SEND_INLINE flag is set, the data buffers can be reused
 // immediately after the call returns.
 #[inline]
-pub unsafe fn ibv_post_send(qp: *mut ibv_qp, wr: *mut ibv_send_wr, bad_wr: *mut *mut ibv_send_wr) -> c_int {
+pub unsafe fn ibv_post_send(
+    qp: *mut ibv_qp,
+    wr: *mut ibv_send_wr,
+    bad_wr: *mut *mut ibv_send_wr,
+) -> c_int {
     (*(*qp).context).ops.post_send.unwrap_unchecked()(qp, wr, bad_wr)
 }
 
 #[inline]
-pub unsafe fn ibv_post_recv(qp: *mut ibv_qp, wr: *mut ibv_recv_wr, bad_wr: *mut *mut ibv_recv_wr) -> c_int {
+pub unsafe fn ibv_post_recv(
+    qp: *mut ibv_qp,
+    wr: *mut ibv_recv_wr,
+    bad_wr: *mut *mut ibv_recv_wr,
+) -> c_int {
     (*(*qp).context).ops.post_recv.unwrap_unchecked()(qp, wr, bad_wr)
 }
 
@@ -907,7 +1009,8 @@ pub unsafe fn rdma_reg_read(id: *mut rdma_cm_id, addr: *mut c_void, length: usiz
         (*id).pd,
         addr,
         length,
-        (ibv_access_flags::IBV_ACCESS_LOCAL_WRITE | ibv_access_flags::IBV_ACCESS_REMOTE_READ).0 as c_int,
+        (ibv_access_flags::IBV_ACCESS_LOCAL_WRITE | ibv_access_flags::IBV_ACCESS_REMOTE_READ).0
+            as c_int,
     )
 }
 
@@ -917,7 +1020,8 @@ pub unsafe fn rdma_reg_write(id: *mut rdma_cm_id, addr: *mut c_void, length: usi
         (*id).pd,
         addr,
         length,
-        (ibv_access_flags::IBV_ACCESS_LOCAL_WRITE | ibv_access_flags::IBV_ACCESS_REMOTE_WRITE).0 as c_int,
+        (ibv_access_flags::IBV_ACCESS_LOCAL_WRITE | ibv_access_flags::IBV_ACCESS_REMOTE_WRITE).0
+            as c_int,
     )
 }
 
@@ -927,7 +1031,12 @@ pub unsafe fn rdma_dereg_mr(mr: *mut ibv_mr) -> c_int {
 }
 
 #[inline]
-pub unsafe fn rdma_post_recvv(id: *mut rdma_cm_id, context: *mut c_void, sgl: *mut ibv_sge, nsge: c_int) -> c_int {
+pub unsafe fn rdma_post_recvv(
+    id: *mut rdma_cm_id,
+    context: *mut c_void,
+    sgl: *mut ibv_sge,
+    nsge: c_int,
+) -> c_int {
     let mut wr = ibv_recv_wr {
         wr_id: context as u64,
         next: ptr::null::<ibv_recv_wr>() as *mut _,


### PR DESCRIPTION
## Summary

Feature-gated mlx5 provider bindings for DC (Dynamically Connected) transport and other mlx5-specific features.

## What's added

When `--features mlx5` is enabled:
- Includes system `<infiniband/mlx5dv.h>` header
- Links against system `libmlx5`
- Generates bindings for `mlx5dv_*` functions and types
- Exposes as `rdma_mummy_sys::mlx5dv` module

Key DC types exposed:
- `mlx5dv_create_qp()` for DCI/DCT QP creation
- `mlx5dv_dc_init_attr` with dc_type (DCI/DCT)
- `mlx5dv_qp_ex` with `wr_set_dc_addr()` for per-WR addressing
- `mlx5dv_context` for capability queries

## Requirements

System-installed mlx5 provider (MLNX_OFED or rdma-core with mlx5).

## Testing

Builds clean on ConnectX-6 with MLNX_OFED 25.01.
No regression without the feature.