### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4](https://github.com/RDMA-Rust/rdma-mummy-sys/compare/v0.2.3...v0.2.4) - 2026-05-23
+
+### Added
+
+- *(mlx5dv)* expose static wrapper bindings
+
+### Fixed
+
+- *(bindings)* allow generated transmute patterns
+- *(example)* remove redundant send flag casts
+- *(clippy)* clean binding wrapper warnings
+
 ## [0.2.3](https://github.com/RDMA-Rust/rdma-mummy-sys/compare/v0.2.2...v0.2.3) - 2026-03-01
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdma-mummy-sys"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
     "Luke Yue <lukedyue@gmail.com>",
     "Pu Wang <nicolas.weeks@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `rdma-mummy-sys`: 0.2.3 -> 0.2.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/RDMA-Rust/rdma-mummy-sys/compare/v0.2.3...v0.2.4) - 2026-05-23

### Added

- *(mlx5dv)* expose static wrapper bindings

### Fixed

- *(bindings)* allow generated transmute patterns
- *(example)* remove redundant send flag casts
- *(clippy)* clean binding wrapper warnings
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).