### PR TITLE
chore: upgrade bindgen to fix code generation with LLVM 22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ paste = "1.0"
 
 [build-dependencies]
 cmake = "0.1"
-bindgen = { version = "0.66", features = ["prettyplease"] }
+bindgen = { version = "0.72.1", features = ["prettyplease"] }


### PR DESCRIPTION
Per https://github.com/rust-lang/rust-bindgen/issues/3264, should fix #24 